### PR TITLE
fix(core): close previous popper if new popper is opened across groups

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
       ],
       "parserOptions": {
         "project": [
-          "tsconfig.json"
+          "tsconfig.app.json"
         ],
         "createDefaultProgram": true
       },

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Ignore all build files
+dist

--- a/projects/workflows-creator/src/lib/builder/builder.component.html
+++ b/projects/workflows-creator/src/lib/builder/builder.component.html
@@ -59,6 +59,7 @@
         (eventAdded)="onEventAdded($event)"
         (actionAdded)="onActionAdded($event)"
         (itemChanged)="onItemChanged($event)"
+        (eventRemoved)="onEventRemoved()"
       ></workflow-group>
     </span>
   </ng-container>

--- a/projects/workflows-creator/src/lib/builder/builder.component.html
+++ b/projects/workflows-creator/src/lib/builder/builder.component.html
@@ -31,6 +31,7 @@
       (eventAdded)="onEventAdded($event)"
       (actionAdded)="onActionAdded($event)"
       (itemChanged)="onItemChanged($event)"
+      (eventRemoved)="onEventRemoved()"
     ></workflow-group>
   </span>
   <ng-container *ngIf="!elseBlockRemoved && !elseBlockHidden">

--- a/projects/workflows-creator/src/lib/builder/builder.component.ts
+++ b/projects/workflows-creator/src/lib/builder/builder.component.ts
@@ -238,12 +238,12 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
       name: event.node.getIdentifier(),
       event: event.newNode.node as WorkflowEvent<E>,
     });
-    this.updateDiagram();
     this.updateState(event.node, event.newNode.inputs);
     this.elseBlockHidden =
       !this.eventGroups[0]?.children?.length &&
       (event.node.getIdentifier() === EventTypes.OnIntervalEvent ||
         event.node.getIdentifier() === EventTypes.OnAddItemEvent);
+    this.updateDiagram();
   }
   /**
    * The function is called when an event is removed from the workflow.

--- a/projects/workflows-creator/src/lib/builder/builder.component.ts
+++ b/projects/workflows-creator/src/lib/builder/builder.component.ts
@@ -459,7 +459,8 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
           case EventTypes.OnValueEvent:
           case ActionTypes.ChangeColumnValueAction:
             const columnExists = !!node.node.state.get('column');
-            const valueExists = !!node.node.state.get('value');
+            const valueExists =
+              typeof node.node.state.get('value') !== 'undefined';
             const valueTypeIsAnyValue =
               node.node.state.get('valueType') === ValueTypes.AnyValue;
             isValid = columnExists && (valueExists || valueTypeIsAnyValue);

--- a/projects/workflows-creator/src/lib/builder/builder.component.ts
+++ b/projects/workflows-creator/src/lib/builder/builder.component.ts
@@ -258,6 +258,7 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
         (events[0].node.getIdentifier() === EventTypes.OnChangeEvent &&
           (events[0].node.state.get('value') === ValueTypes.AnyValue ||
             events[0].node.state.get('valueType') === ValueTypes.AnyValue)));
+    this.updateDiagram();
   }
   /**
    * When an action is added, emit an event with the name of the action and the action itself, update

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -1,10 +1,4 @@
 <div class="tree-group" [ngClass]="{'no-node': !group.children?.length}">
-  <workflow-tooltip-render
-    [showsTooltip]="showsTooltip"
-    [tooltipText]="tooltipText"
-    [topPosition]="topPosition"
-    [leftPosition]="leftPosition"
-  ></workflow-tooltip-render>
   <div class="workflow-group">
     <div class="workflow-group-content">
       <span *ngIf="!isFirst"> {{ group.name }} </span>
@@ -119,6 +113,14 @@
             }}
           </span>
         </div>
+        <workflow-tooltip-render
+          *ngIf="shouldShowTooltip(nodeWithInput, input)"
+          [showsTooltip]="showsTooltip"
+          [tooltipText]="tooltipText"
+          [topPosition]="topPosition"
+          [leftPosition]="null"
+          [rightPosition]="rightPosition"
+        ></workflow-tooltip-render>
         {{
           (input.suffix?.state
             ? nodeWithInput.node.state.get(input.suffix?.state)

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -230,6 +230,7 @@
     let-list="list"
     let-callback="callback"
     let-hide="hide"
+    let-nodeWithInput="nodeWithInput"
   >
     <div (document:click)="hide()">
       <ng-select

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -11,7 +11,7 @@
         [popperHideOnScroll]="true"
         [popperTrigger]="'click'"
         [popperPlacement]="'bottom'"
-        (click)="openPopup(group.nodeType)"
+        (click)="openPopup(group.nodeType, nodePopup)"
       >
         <span *ngIf="group.nodeType === types.EVENT">
           {{ localizedStringKeys.WhenThisHappens | localization }}
@@ -53,7 +53,7 @@
       [isFirst]="i === 0"
       [inputTemplate]="inputs"
       [popupTemplate]="nodePopup"
-      (add)="openPopup(group.nodeType)"
+      (add)="openPopup(group.nodeType, nodePopup)"
       (remove)="onNodeRemove(i)"
     ></workflow-node>
   </span>

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -285,7 +285,7 @@
       </div>
       <div>
         <button
-          class="close-btn"
+          class="close-btn-lib"
           (click)="
             callback(
               getLibraryValue(
@@ -319,7 +319,7 @@
         </div>
         <div>
           <button
-            class="close-btn"
+            class="close-btn-lib"
             (click)="
               callback(
                 getLibraryValue(

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -374,7 +374,7 @@
       </div>
       <div class="set-email-btn">
         <button
-          class="close-btn"
+          class="close-btn-lib"
           (click)="callback(emailInput)"
           [disabled]="!emailInput.subject || !emailInput.body"
         >

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -199,6 +199,7 @@
         (mousedown)="handleMouseDown($event)"
         (mouseup)="handleMouseUp()"
         (mouseleave)="handleMouseLeave($event)"
+        (keydown)="handleKeyPress($event)"
       />
     </div>
   </ng-template>

--- a/projects/workflows-creator/src/lib/builder/group/group.component.scss
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.scss
@@ -292,7 +292,7 @@ input[type="time"]:focus {
     padding: 20px;
     justify-content: space-between;
   }
-  .close-btn {
+  .close-btn-lib {
     @include theme;
     height: 40px;
     padding: 0 10px;
@@ -310,7 +310,7 @@ input[type="time"]:focus {
   .date-input{
     margin-right: 10px;
   }
-  .close-btn {
+  .close-btn-lib {
     @include theme;
     height: 35px;
     padding: 0 10px;

--- a/projects/workflows-creator/src/lib/builder/group/group.component.scss
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.scss
@@ -204,9 +204,8 @@ input[type="time"]:focus {
     .set-email-btn {
       text-align: right;
       padding: 10px;
-      .close-btn {
-        background: $black;
-        color: $white;
+      .close-btn-lib {
+        @include theme;
         cursor: pointer;
         font-size: 13px;
         padding: 5px 20px;

--- a/projects/workflows-creator/src/lib/builder/group/group.component.scss
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.scss
@@ -43,7 +43,7 @@ input[type="date"]::-webkit-clear-button {
 }
 
 /* Removes the spin button */
-input[type="date"]::-webkit-inner-spin-button { 
+input[type="date"]::-webkit-inner-spin-button {
   display: none;
 }
 
@@ -79,7 +79,7 @@ input[type="time"]::-webkit-clear-button {
 }
 
 /* Removes the spin button */
-input[type="time"]::-webkit-inner-spin-button { 
+input[type="time"]::-webkit-inner-spin-button {
   display: none;
 }
 
@@ -161,7 +161,7 @@ input[type="time"]:focus {
     .value-text {
       display: inline-block;
       overflow: hidden;
-      max-width: 45%;
+      max-width: 15rem;
       text-decoration: inherit;
       text-overflow: ellipsis;
       vertical-align: top;

--- a/projects/workflows-creator/src/lib/builder/group/group.component.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.ts
@@ -292,8 +292,15 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
    * the node list to the trigger events if there is only one event group and no children, otherwise
    * set the node list to the events
    * @param {NodeTypes} type - NodeTypes
+   * @param {NgxPopperjsContentComponent} popper - NgxPopperjsContentComponent - this is the popper
    */
-  openPopup(type: NodeTypes) {
+  openPopup(type: NodeTypes, popper: NgxPopperjsContentComponent) {
+    this.prevPopperRef?.hide();
+    this.groupService.previousPopper?.hide();
+    this.groupService.previousPopper?.popperInstance.forceUpdate();
+    this.prevPopperRef = popper;
+    this.groupService.previousPopper = popper;
+
     if (type === NodeTypes.ACTION) {
       this.nodeList = this.actions;
     } else if (type === NodeTypes.EVENT) {

--- a/projects/workflows-creator/src/lib/builder/group/group.component.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.ts
@@ -41,6 +41,7 @@ import {
   GatewayElement,
   LocalizationProviderService,
   ReadColumnValue,
+  ToValueInput,
   TriggerWhenColumnChanges,
 } from '../../services';
 import {LocalizationPipe} from '../../pipes/localization.pipe';
@@ -135,7 +136,7 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
   showsTooltip = false;
   tooltipText = 'This is default parent component text';
   topPosition: any;
-  leftPosition: any;
+  rightPosition: any;
 
   public types = NodeTypes;
   public prevPopperRef: NgxPopperjsContentComponent;
@@ -414,6 +415,20 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
    * @param {WorkflowPrompt} input - WorkflowPrompt - this is the input object that was clicked on
    */
   showTooltip(e: MouseEvent, element: NodeWithInput<E>, input: WorkflowPrompt) {
+    if (this.shouldShowTooltip(element, input)) {
+      this.tooltipText = this.localizationSvc.getLocalizedString(
+        LocalizedStringKeys.SelectColumnTooltip,
+      );
+      this.showsTooltip = true;
+      this.topPosition = 35;
+      this.rightPosition = 150;
+      if (input instanceof ToValueInput) {
+        this.rightPosition = 250;
+      }
+    }
+  }
+
+  public shouldShowTooltip(element: NodeWithInput<E>, input: WorkflowPrompt) {
     if (
       ['condition', 'value'].includes(input.inputKey) &&
       (element.node.elements.includes(ChangeColumnValue.identifier) ||
@@ -421,13 +436,10 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
         element.node.elements.includes(ReadColumnValue.identifier)) &&
       !element.node.state.get('column')
     ) {
-      this.tooltipText = this.localizationSvc.getLocalizedString(
-        LocalizedStringKeys.SelectColumnTooltip,
-      );
-      this.showsTooltip = true;
-      this.topPosition = e.clientY + 10;
-      this.leftPosition = e.clientX;
+      return true;
     }
+
+    return false;
   }
 
   /**
@@ -436,7 +448,7 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
   hideTooltip() {
     this.showsTooltip = false;
     this.topPosition = null;
-    this.leftPosition = null;
+    this.rightPosition = null;
   }
 
   /**

--- a/projects/workflows-creator/src/lib/builder/group/group.component.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.ts
@@ -45,6 +45,7 @@ import {
 } from '../../services';
 import {LocalizationPipe} from '../../pipes/localization.pipe';
 import moment from 'moment';
+import {GroupService} from './group.service';
 
 @Component({
   selector: 'workflow-group',
@@ -59,6 +60,7 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
   constructor(
     private readonly nodes: NodeService<E>,
     private readonly localizationSvc: LocalizationProviderService,
+    private readonly groupService: GroupService,
   ) {}
   public inputType = InputTypes;
   private isMouseDown: boolean = false;
@@ -395,7 +397,10 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
    */
   onPoperClick(event: MouseEvent, popper: NgxPopperjsContentComponent) {
     this.prevPopperRef?.hide();
+    this.groupService.previousPopper?.hide();
+    this.groupService.previousPopper?.popperInstance.forceUpdate();
     this.prevPopperRef = popper;
+    this.groupService.previousPopper = popper;
     event.preventDefault();
     event.stopPropagation();
     this.prevPopperRef.show();

--- a/projects/workflows-creator/src/lib/builder/group/group.component.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.ts
@@ -633,4 +633,14 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
       element.node.state.remove(`${nextKey}Name`);
     }
   }
+
+  handleKeyPress(event: any) {
+    const keyCode = event.which || event.keyCode;
+    const isDigit = keyCode >= 48 && keyCode <= 57;
+    const isBackspaceOrDelete = [8, 46].includes(keyCode);
+    if (!(isDigit || isBackspaceOrDelete)) event.preventDefault();
+    const inputValue = event.target.value;
+    const isValidInput = /^-?\d*\.?\d*$/.test(inputValue);
+    if (!isValidInput) event.preventDefault();
+  }
 }

--- a/projects/workflows-creator/src/lib/builder/group/group.service.spec.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GroupService } from './group.service';
+
+describe('GroupService', () => {
+  let service: GroupService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GroupService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/workflows-creator/src/lib/builder/group/group.service.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.service.ts
@@ -1,0 +1,11 @@
+import {Injectable} from '@angular/core';
+import {NgxPopperjsContentComponent} from 'ngx-popperjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GroupService {
+  public previousPopper?: NgxPopperjsContentComponent;
+
+  constructor() {}
+}

--- a/projects/workflows-creator/src/lib/builder/tooltip-render/tooltip-render.component.html
+++ b/projects/workflows-creator/src/lib/builder/tooltip-render/tooltip-render.component.html
@@ -3,6 +3,7 @@
     class="tooltip"
     [style.top]="topPosition + 'px'"
     [style.left]="leftPosition + 'px'"
+    [style.right]="rightPosition + 'px'"
   >
     {{ tooltipText }}
   </div>

--- a/projects/workflows-creator/src/lib/builder/tooltip-render/tooltip-render.component.ts
+++ b/projects/workflows-creator/src/lib/builder/tooltip-render/tooltip-render.component.ts
@@ -10,6 +10,7 @@ export class TooltipRenderComponent {
   @Input() tooltipText = 'Default tooltip text';
   @Input() topPosition = 215;
   @Input() leftPosition = 400;
+  @Input() rightPosition = 150;
 
   constructor() {}
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "90788b80097a03917ae5eb70f77bc7f6b74ac194fe063243573f2f673458f1d8"
+  "hash": "6c9107a0c33b956a52bc45766ca9fd90ac155cb71a13e718ca394d3f13814207"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "23c5bcff081f76fbe83fed22f00ff137c05c472d7c169b75f4af7766c8aea85e"
+  "hash": "d4a123c95014fbf1eb737e0c6a86839feeba514cc3a6460c90829fbe55d2808d"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "d4a123c95014fbf1eb737e0c6a86839feeba514cc3a6460c90829fbe55d2808d"
+  "hash": "e2601e25c8bb8a8ab036fcb64b7948bd3e9eee6c868654b79ed51cd600f2dbf9"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "f6cee17ddedc9cac6947644eee9e1900606d5c00787dcb2fd8fc03cd61265550"
+  "hash": "1c2dedcbcfb28134a70be08281eab8f9952a9b45e65659de7e56a3d39d5fafb3"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "5089063862ff549d94e05b6c46abed2cf786ba5a6d5704d206981e31c247f984"
+  "hash": "23c5bcff081f76fbe83fed22f00ff137c05c472d7c169b75f4af7766c8aea85e"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "8eb49ead733e56f2c1c9b89176e0b56ce4e6dfd6c22bce2e82e4a623c95ddf65"
+  "hash": "1dd19f4dbb1753c89acdf0a10e45f998b6dc6852e20343774481427a5f83071a"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "6c9107a0c33b956a52bc45766ca9fd90ac155cb71a13e718ca394d3f13814207"
+  "hash": "5089063862ff549d94e05b6c46abed2cf786ba5a6d5704d206981e31c247f984"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "1dd19f4dbb1753c89acdf0a10e45f998b6dc6852e20343774481427a5f83071a"
+  "hash": "f6cee17ddedc9cac6947644eee9e1900606d5c00787dcb2fd8fc03cd61265550"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "590a5cacd26f289c2eaf4f786bddd3ce926486de5b44b86b0130359132f7268c"
+  "hash": "0266e37820cb68ebcd923b40c4a3910fb9c44f694a7f7685f8227c3f4a85140f"
 }

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "1c2dedcbcfb28134a70be08281eab8f9952a9b45e65659de7e56a3d39d5fafb3"
+  "hash": "590a5cacd26f289c2eaf4f786bddd3ce926486de5b44b86b0130359132f7268c"
 }


### PR DESCRIPTION


## Description

Added a GroupService to store popper instance, then closing the previous popper if new one is opened. Previously only popper within same group was closing, with this changes, popper across group will be closed if new popper is opened

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [x] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
