### PR TITLE
fix(core): allow only 4 digits for year in date input

### DIFF
--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -278,12 +278,15 @@
           type="date"
           [(ngModel)]="date"
           (click)="$event.stopPropagation()"
+          min="0000-01-01"
+          max="9999-12-31"
           (keydown)="
             handleEnterEvent(
               callback,
               nodeWithInput.node,
               {target: {value: date}},
-              inputType.Date
+              inputType.Date,
+              $event
             )
           "
         />

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -324,7 +324,7 @@
         </div>
         <div>
           <button
-            class="close-button"
+            class="close-btn"
             (click)="
               callback(
                 getLibraryValue(
@@ -379,7 +379,7 @@
       </div>
       <div class="set-email-btn">
         <button
-          class="close-button"
+          class="close-btn"
           (click)="callback(emailInput)"
           [disabled]="!emailInput.subject || !emailInput.body"
         >

--- a/projects/workflows-creator/src/lib/builder/group/group.component.html
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.html
@@ -324,7 +324,7 @@
         </div>
         <div>
           <button
-            class="close-btn"
+            class="close-button"
             (click)="
               callback(
                 getLibraryValue(
@@ -379,7 +379,7 @@
       </div>
       <div class="set-email-btn">
         <button
-          class="close-btn"
+          class="close-button"
           (click)="callback(emailInput)"
           [disabled]="!emailInput.subject || !emailInput.body"
         >

--- a/projects/workflows-creator/src/lib/builder/group/group.component.ts
+++ b/projects/workflows-creator/src/lib/builder/group/group.component.ts
@@ -590,11 +590,19 @@ export class GroupComponent<E> implements OnInit, AfterViewInit {
     }
   }
 
-  handleEnterEvent(callback:any, node: BpmnNode,
+  handleEnterEvent(
+    callback: any,
+    node: BpmnNode,
     $event: any,
-    type: string, metaObj: RecordOfAnyType,){
-    const response =this.getLibraryValue(node,$event,type,metaObj)
-    callback(response)
+    type: string,
+    event: any,
+  ) {
+    const response = this.getLibraryValue(node, $event, type, {});
+
+    //check whether the entered key is "ENTER" key
+    if (event.keyCode === 13) {
+      callback(response);
+    }
   }
   /**
    * It removes all the inputs that come after the current input

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,5 +17,5 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "8eb49ead733e56f2c1c9b89176e0b56ce4e6dfd6c22bce2e82e4a623c95ddf65"
+  "hash": "dcf1a1f2be58ff3c5e990054ae2b6fe57be1c2b36c941ad31f7a06b60be5c17f"
 }


### PR DESCRIPTION
## Description

1. Allow only 4 digits for year in date input
2. Fix the issue when enter date with keyboard

Fixes #56 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
