### PR TITLE
fix(core): Values are not retained after saving for 'Else Do this' block

### DIFF
--- a/projects/workflows-creator/src/lib/builder/builder.component.ts
+++ b/projects/workflows-creator/src/lib/builder/builder.component.ts
@@ -219,7 +219,8 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
       return;
     }
 
-    let value = firstEvent.state.get('value');
+    // let value = firstEvent.state.get('value');
+    let value = events.length > 0 ? firstEvent?.state.get('value') : undefined;
 
     if (typeof value === 'object') {
       value = value.value;

--- a/projects/workflows-creator/src/lib/builder/builder.component.ts
+++ b/projects/workflows-creator/src/lib/builder/builder.component.ts
@@ -209,22 +209,32 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
    * This function checks if the else block should be hidden based on the type and number of events in
    * the event group.
    */
+
   hideElseBlockIfRequired() {
     const events = this.eventGroups[0].children;
-    let value = events[0].node.state.get('value');
+    const firstEvent = events[0]?.node;
+
+    if (events.length !== 1 || !firstEvent) {
+      this.elseBlockHidden = false;
+      return;
+    }
+
+    let value = firstEvent.state.get('value');
+
     if (typeof value === 'object') {
       value = value.value;
     }
-    if (events.length !== 1) {
-      this.elseBlockHidden = false;
-    } else {
-      this.elseBlockHidden =
-        events[0].node.getIdentifier() === EventTypes.OnIntervalEvent ||
-        events[0].node.getIdentifier() === EventTypes.OnAddItemEvent ||
-        (events[0].node.getIdentifier() === EventTypes.OnChangeEvent &&
-          (value === ValueTypes.AnyValue ||
-            events[0].node.state.get('valueType') === ValueTypes.AnyValue));
-    }
+
+    const eventType = firstEvent.getIdentifier();
+    const eventValue = firstEvent.state.get('value');
+    const eventValueType = firstEvent.state.get('valueType');
+
+    this.elseBlockHidden =
+      eventType === EventTypes.OnIntervalEvent ||
+      eventType === EventTypes.OnAddItemEvent ||
+      (eventType === EventTypes.OnChangeEvent &&
+        (eventValue === ValueTypes.AnyValue ||
+          eventValueType === ValueTypes.AnyValue));
   }
 
   /**

--- a/projects/workflows-creator/src/lib/builder/builder.component.ts
+++ b/projects/workflows-creator/src/lib/builder/builder.component.ts
@@ -202,8 +202,31 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
         });
       });
       this.updateDiagram();
+      this.hideElseBlockIfRequired();
     }
   }
+  /**
+   * This function checks if the else block should be hidden based on the type and number of events in
+   * the event group.
+   */
+  hideElseBlockIfRequired() {
+    const events = this.eventGroups[0].children;
+    let value = events[0].node.state.get('value');
+    if (typeof value === 'object') {
+      value = value.value;
+    }
+    if (events.length !== 1) {
+      this.elseBlockHidden = false;
+    } else {
+      this.elseBlockHidden =
+        events[0].node.getIdentifier() === EventTypes.OnIntervalEvent ||
+        events[0].node.getIdentifier() === EventTypes.OnAddItemEvent ||
+        (events[0].node.getIdentifier() === EventTypes.OnChangeEvent &&
+          (value === ValueTypes.AnyValue ||
+            events[0].node.state.get('valueType') === ValueTypes.AnyValue));
+    }
+  }
+
   /**
    * If the group is an event, add it to the eventGroups array, otherwise if it's an action, add it to
    * the actionGroups array
@@ -273,6 +296,7 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
     });
     this.updateDiagram();
     this.updateState(action.node, action.newNode.inputs);
+    this.hideElseBlockIfRequired();
   }
   /**
    * The function is called when an item is changed in the UI. It emits an event to the parent
@@ -286,16 +310,7 @@ export class BuilderComponent<E> implements OnInit, OnChanges {
       item: item.element.node,
     });
     this.updateState(item.element.node, item.element.inputs);
-    // TODO: to be refactored
-    // to hide else block when anything is selected in ValueInput or ValueTypeInput
-    this.elseBlockHidden =
-      this.eventGroups[0].children?.length === 1 &&
-      this.eventGroups[0].children[0].node.getIdentifier() ===
-        EventTypes.OnChangeEvent &&
-      (this.eventGroups[0].children[0].node.state.get('value') ===
-        ValueTypes.AnyValue ||
-        this.eventGroups[0].children[0].node.state.get('valueType') ===
-          ValueTypes.AnyValue);
+    this.hideElseBlockIfRequired();
     this.updateDiagram();
   }
   /**

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,6 +17,6 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "b3becb84440a55958bc16f9caf46b27fe1c7aab612e7fee3df4539591abee228"
+  "hash": "853bef78b9dcd9c176ad24ff687b712172ea5c2f610b41b15ee24ba65309c129"
 }
 

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,6 +17,6 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "853bef78b9dcd9c176ad24ff687b712172ea5c2f610b41b15ee24ba65309c129"
+  "hash": "24191f21fc1004d7e80232918f4268c427089e3248f3c474b69e24a941a704bf"
 }
 

--- a/projects/workflows-element/package.json
+++ b/projects/workflows-element/package.json
@@ -17,6 +17,6 @@
     "access": "public",
     "directory": "dist"
   },
-  "hash": "24191f21fc1004d7e80232918f4268c427089e3248f3c474b69e24a941a704bf"
+  "hash": "2de169ac759548f51f2397daa81b6187fa75d7ca99c31f0f14e9ab95335919fb"
 }
 


### PR DESCRIPTION
WF| Values are not retained after saving for 'Else Do this' block when 'Item/Subitem is created' is selected in the workflow
for further information please check the following link
GH-71

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #71 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
